### PR TITLE
installer: ensure successful status/$?

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -128,11 +128,11 @@ export default class Installer {
           out.write('`tabtab uninstall ' + name + '`');
 
           if (this.template === 'fish') {
-            out.write('\n[ -f ' + filename + ' ]; and . ' + filename);
+            out.write('\n[ -f ' + filename + ' ]; and . ' + filename + '; or true');
           } else if (this.template === 'zsh') {
-            out.write('\n[[ -f ' + filename + ' ]] && . ' + filename);
+            out.write('\n[[ -f ' + filename + ' ]] && . ' + filename + ' || true');
           } else {
-            out.write('\n[ -f ' + filename + ' ] && . ' + filename);
+            out.write('\n[ -f ' + filename + ' ] && . ' + filename + ' || true');
           }
         });
       });


### PR DESCRIPTION
I am displaying the last commands exit status in my Zsh shell prompt
(`$?`), and installing a package using tabtab caused it to become 1.

Instead of `|| true` this could use an `if`.