### PR TITLE
Added function to escape regular expression chars

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -46,6 +46,16 @@ const scriptFromShell = (shell = systemShell()) => {
 };
 
 /**
+ * Helper to escape regular expression chars
+ *
+ * @param {String} str - String to escape the chars from
+ * @returns The escaped text
+ */
+const escapeRegExp = (str) => {
+  return str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+/**
  * Helper to return the expected location for SHELL config file, based on the
  * provided shell value.
  *
@@ -122,7 +132,7 @@ const checkFilenameForLine = async (filename, line) => {
     }
   }
 
-  return !!filecontent.match(`${line}`);
+  return !!filecontent.match(escapeRegExp(`${line}`));
 };
 
 /**
@@ -324,7 +334,7 @@ const removeLinesFromFilename = async (filename, name) => {
     ? `# tabtab source for packages`
     : `# tabtab source for ${name} package`;
 
-  const hasLine = !!filecontent.match(`${sourceLine}`);
+  const hasLine = !!filecontent.match(escapeRegExp(`${sourceLine}`));
   if (!hasLine) {
     return debug('File %s does not include the line: %s', filename, sourceLine);
   }


### PR DESCRIPTION
In the case of a binary filename containing characters that have a special meaning inside regular expressions, the installation/uninstallation fails.

Source for the solution:

https://stackoverflow.com/a/9310752