### PR TITLE
package.json: specify the files to include

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-docs/
-note.txt
-.nyc_output/
-quick-test.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "name": "tabtab",
   "description": "tab completion helpers, for node cli programs. Inspired by npm completion.",
   "main": "lib/index.js",
+  "files": [
+    "lib/**/*.{js,sh}"
+  ],
   "scripts": {
     "test": "mkdirp ~/.config/tabtab && DEBUG='tabtab*' c8 mocha --timeout 5000",
     "posttest": "npm run eslint",


### PR DESCRIPTION
```
C:\Users\xmr\Desktop\tabtab>npm pack --dry
npm notice
npm notice package: tabtab@3.0.2
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 314B   lib/constants.js
npm notice 4.9kB  lib/index.js
npm notice 12.6kB lib/installer.js
npm notice 1.9kB  lib/prompt.js
npm notice 834B   lib/scripts/bash.sh
npm notice 495B   lib/scripts/fish.sh
npm notice 391B   lib/scripts/zsh.sh
npm notice 347B   lib/utils/exists.js
npm notice 190B   lib/utils/index.js
npm notice 353B   lib/utils/systemShell.js
npm notice 822B   lib/utils/tabtabDebug.js
npm notice 1.8kB  package.json
npm notice 13.0kB readme.md
npm notice === Tarball Details ===
npm notice name:          tabtab
npm notice version:       3.0.2
npm notice filename:      tabtab-3.0.2.tgz
npm notice package size:  12.8 kB
npm notice unpacked size: 39.1 kB
npm notice shasum:        a20149aca720801ea7bab77410afb4b6e2fef47f
npm notice integrity:     sha512-lljsDGdtOy1NH[...]g7PWweneSLhAw==
npm notice total files:   14
npm notice
tabtab-3.0.2.tgz
```

Most importantly, this gets rid of `coverage` files which are currently included in the npm package, see https://packagephobia.com/result?p=tabtab

/CC @mklabs 